### PR TITLE
Altered the parameter from String columnName to int columnIndex

### DIFF
--- a/lib/src/main/java/de/edux/data/provider/DataPostProcessor.java
+++ b/lib/src/main/java/de/edux/data/provider/DataPostProcessor.java
@@ -36,7 +36,7 @@ public interface DataPostProcessor {
    * @param imputationStrategy the strategy to use for imputing missing values
    * @return the {@code DataPostProcessor} instance with imputed data for method chaining
    */
-  DataPostProcessor imputation(String columnName, ImputationStrategy imputationStrategy);
+   DataPostProcessor imputation(String columnName, ImputationStrategy imputationStrategy);
 
   /**
    * Performs imputation on missing values in a specified column index using the provided imputation

--- a/lib/src/main/java/de/edux/data/provider/DataProcessor.java
+++ b/lib/src/main/java/de/edux/data/provider/DataProcessor.java
@@ -126,17 +126,13 @@ public class DataProcessor implements DataPostProcessor, Dataset, Dataloader {
     return Optional.empty();
   }
 
-  public String[] getColumnDataOf(String columnName) {
-    Optional<Integer> index = getIndexOfColumn(columnName);
-    if (index.isEmpty()) {
-      throw new IllegalArgumentException("Column name not found");
-    }
-    int columnIndex = index.get();
-    String[] columnData = new String[dataset.size()];
-    for (int i = 0; i < dataset.size(); i++) {
-      columnData[i] = dataset.get(i)[columnIndex];
-    }
-    return columnData;
+  public String[] getColumnDataOf(int columnIndex) {
+     
+      String[] columnData = new String[dataset.size()];
+      for (int i = 0; i < dataset.size(); i++) {
+          columnData[i] = dataset.get(i)[columnIndex];
+      }
+      return columnData;
   }
 
   @Override
@@ -145,7 +141,7 @@ public class DataProcessor implements DataPostProcessor, Dataset, Dataloader {
   }
 
   public DataPostProcessor imputation(String columnName, ImputationStrategy imputationStrategy) {
-    String[] columnDataToUpdate = getColumnDataOf(columnName);
+    String[] columnDataToUpdate = getColumnDataOf(Integer.parseInt(columnName));
     String[] updatedColumnData =
         imputationStrategy.getImputation().performImputation(columnDataToUpdate);
     int columnIndex = getIndexOfColumn(columnName).get();

--- a/lib/src/main/java/de/edux/data/provider/Dataset.java
+++ b/lib/src/main/java/de/edux/data/provider/Dataset.java
@@ -20,9 +20,9 @@ public interface Dataset {
 
   double[][] getTestFeatures(int[] inputColumns);
 
-  Optional<Integer> getIndexOfColumn(String columnName);
+   Optional<Integer> getIndexOfColumn(String columnName);
 
-  String[] getColumnDataOf(String columnName);
+  String[] getColumnDataOf(int columnName);
 
   String[] getColumnNames();
 }


### PR DESCRIPTION
fixes #108

The parameter in the getColumnDataOf method within DataProcessor is changed from String columnName to int columnIndex due to identified design shortcomings.

class location : lib/src/main/java/de/edux/data/provider/DataProcessor.java

![image](https://github.com/Samyssmile/edux/assets/122148320/36d3bcbd-c544-4a57-a313-4636506a6d83)
