### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build
 
 on:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,6 @@
+name: Build
 permissions:
   contents: read
-name: Build
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Samyssmile/edux/security/code-scanning/2](https://github.com/Samyssmile/edux/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since this workflow only checks out code and builds it (does not appear to require write access to the repository or to issues/pull-requests), the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the `build` job). The best practice is to add it at the workflow level, just after the `name` and before the `on` block, to ensure all jobs inherit these minimal permissions unless overridden.

**What to change:**  
- In `.github/workflows/gradle.yml`, add the following block after the `name: Build` line and before the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
